### PR TITLE
Added example of a protected page... 

### DIFF
--- a/wagtail_client/settings.py
+++ b/wagtail_client/settings.py
@@ -111,7 +111,6 @@ ROOT_URLCONF = 'wagtail_client.urls'
 
 AUTHENTICATION_BACKENDS = (
     'girleffect_oidc_integration.auth.GirlEffectOIDCBackend',
-    #'django.contrib.auth.backends.ModelBackend',
 )
 
 TEMPLATES = [

--- a/wagtail_client/settings.py
+++ b/wagtail_client/settings.py
@@ -44,7 +44,7 @@ OIDC_OP_USER_ENDPOINT = os.environ['OIDC_OP_USER_ENDPOINT']
 
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 15 * 60  # 15 minutes
 
-
+LOGIN_URL = reverse_lazy("oidc_authentication_init")
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 
@@ -110,8 +110,8 @@ MIDDLEWARE = [
 ROOT_URLCONF = 'wagtail_client.urls'
 
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
     'girleffect_oidc_integration.auth.GirlEffectOIDCBackend',
+    #'django.contrib.auth.backends.ModelBackend',
 )
 
 TEMPLATES = [

--- a/wagtail_client/templates/wagtail_client/home.html
+++ b/wagtail_client/templates/wagtail_client/home.html
@@ -44,6 +44,11 @@
                 </p>
                 <a class="button" href="{% url 'oidc_authentication_init' %}">Login</a>
                 <p>
+                    You can also navigate to a protected page (one that requires you to be logged in) and it will
+                    automatically redirect you to the login page on the Identity Provider.
+                </p>
+                <a class="button" href="{% url 'protected' %}">Go to a protected page</a>
+                <p>
                     Registration functionality can be tailored per site. Below we have 2 typical registration buttons, one
                     for "end users" (2FA not required, less required fields) and "system users" (2FA required, more required
                     fields, more stringent password requirements).

--- a/wagtail_client/templates/wagtail_client/protected.html
+++ b/wagtail_client/templates/wagtail_client/protected.html
@@ -1,0 +1,26 @@
+{% extends "wagtailadmin/admin_base.html" %}
+
+{% load static %}
+
+{% block titletag %}
+    Protected page
+{% endblock %}
+{% block extra_css %}
+    {{ block.super }}
+    {% if settings.SITE_CODE == "springster" %}
+        <link rel="stylesheet" href="{% static "wagtail_client/css/springster.css" %}">
+    {% elif settings.SITE_CODE == "ninyampinga" %}
+        <link rel="stylesheet" href="{% static "wagtail_client/css/ninyampinga.css" %}">
+    {% endif %}
+{% endblock %}
+
+{% block furniture %}
+    <div class="content-wrapper">
+        <div class="content">
+            <h1>Welcome <i>{{ user.first_name }}</i> to the protected page</h1>
+            <div class="submit">
+                <a class="button" href="{% url "logout" %}">Logout</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/wagtail_client/urls.py
+++ b/wagtail_client/urls.py
@@ -13,25 +13,25 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf import settings
-from django.conf.urls.static import static
 from django.conf.urls import url, include
 from django.contrib import admin
-from django.views.generic.base import TemplateView
 from django.contrib.auth.views import logout
+from django.views.generic import RedirectView
 
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 
-from wagtail_client.views import HomePageView
+from wagtail_client.views import HomePageView, ProtectedPageView
 
 urlpatterns = [
+    url(r'^admin/login/', RedirectView.as_view(pattern_name="oidc_authentication_init")),
     url(r'^admin/', admin.site.urls),
     url(r'^cms/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^pages/', include(wagtail_urls)),
     url(r'^oidc/', include('mozilla_django_oidc.urls')),
+    url(r'^protected/', ProtectedPageView.as_view(), name="login"),
     url(r'^login/', HomePageView.as_view(), name="login"),
     url(r"^$", HomePageView.as_view(), name="home"),
     url(r"^logout/", logout, name="logout"),

--- a/wagtail_client/urls.py
+++ b/wagtail_client/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^pages/', include(wagtail_urls)),
     url(r'^oidc/', include('mozilla_django_oidc.urls')),
-    url(r'^protected/', ProtectedPageView.as_view(), name="login"),
+    url(r'^protected/', ProtectedPageView.as_view(), name="protected"),
     url(r'^login/', HomePageView.as_view(), name="login"),
     url(r"^$", HomePageView.as_view(), name="home"),
     url(r"^logout/", logout, name="logout"),

--- a/wagtail_client/views.py
+++ b/wagtail_client/views.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 
@@ -10,5 +12,18 @@ class HomePageView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(HomePageView, self).get_context_data(**kwargs)
+        context["settings"] = settings
+        return context
+
+
+@method_decorator(login_required, name="dispatch")
+class ProtectedPageView(TemplateView):
+    """
+    A protected page view that with some customisable features.
+    """
+    template_name = "wagtail_client/protected.html"
+
+    def get_context_data(self, **kwargs):
+        context = super(ProtectedPageView, self).get_context_data(**kwargs)
         context["settings"] = settings
         return context


### PR DESCRIPTION
...which automatically redirects to the Identity Provider for login, and then redirects back to the protected page. This will work in general for any page requiring a user to be logged in.